### PR TITLE
fixed extraArgs is not defined

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ function loadOutput(environment) {
 function loadPlugins(environment) {
 
     let wasmPackArgs = '--no-typescript';
-    if (environment.production) extraArgs += ' --release';
+    if (environment.production) wasmPackArgs += ' --release';
 
     return [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
fixed when  `npm run build` throw "extraArgs is not defined"